### PR TITLE
MultiFormatter format SpreadsheetLocaleDefaultDateTimeFormat support

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatter.java
@@ -21,6 +21,7 @@ import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
 import walkingkooka.spreadsheet.format.HasSpreadsheetFormatter;
 import walkingkooka.text.CharSequences;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -84,6 +85,11 @@ final class MultiFormatter implements Function<MultiFormatRequest, MultiFormatRe
                 final HasSpreadsheetFormatter hasSpreadsheetFormatter = (HasSpreadsheetFormatter) pattern;
                 formatted = this.engineContext.format(value, hasSpreadsheetFormatter.formatter())
                         .orElseThrow(() -> this.formatFail(value, pattern));
+                break;
+            }
+            if (pattern instanceof SpreadsheetLocaleDefaultDateTimeFormat) {
+                final SpreadsheetLocaleDefaultDateTimeFormat format = (SpreadsheetLocaleDefaultDateTimeFormat) pattern;
+                formatted = format.format((LocalDateTime) value, this.engineContext);
                 break;
             }
 

--- a/src/main/java/walkingkooka/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormat.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormat.java
@@ -17,13 +17,19 @@
 
 package walkingkooka.spreadsheet.server.format;
 
+import walkingkooka.locale.HasLocale;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Objects;
+
 /**
- * Formats a {@link java.time.LocalDateTime} using the spreadsheet locale using the default format pattern.
+ * Formats a {@link LocalDateTime} using the spreadsheet locale using the default format pattern.
  */
 public final class SpreadsheetLocaleDefaultDateTimeFormat {
 
@@ -36,6 +42,18 @@ public final class SpreadsheetLocaleDefaultDateTimeFormat {
         super();
     }
 
+    String format(final LocalDateTime dateTime,
+                  final HasLocale context) {
+        Objects.requireNonNull(dateTime, "dateTime");
+        Objects.requireNonNull(context, "context");
+
+        return dateTime.format(
+                DateTimeFormatter
+                .ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.MEDIUM)
+                .withLocale(context.locale())
+        );
+    }
+
     @Override
     public String toString() {
         return this.getClass().getSimpleName();
@@ -44,7 +62,7 @@ public final class SpreadsheetLocaleDefaultDateTimeFormat {
     // Json.............................................................................................................
 
     private JsonNode marshall(final JsonNodeMarshallContext context) {
-        return JsonNode.nullNode();
+        return JsonNode.number(1);
     }
 
     static SpreadsheetLocaleDefaultDateTimeFormat unmarshall(final JsonNode node,

--- a/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetServerApiSpreadsheetEngineBiConsumerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetServerApiSpreadsheetEngineBiConsumerTest.java
@@ -51,6 +51,7 @@ import walkingkooka.spreadsheet.security.store.SpreadsheetUserStores;
 import walkingkooka.spreadsheet.server.format.FormatRequest;
 import walkingkooka.spreadsheet.server.format.MultiFormatRequest;
 import walkingkooka.spreadsheet.server.format.MultiFormatResponse;
+import walkingkooka.spreadsheet.server.format.SpreadsheetLocaleDefaultDateTimeFormat;
 import walkingkooka.spreadsheet.server.parse.MultiParseRequest;
 import walkingkooka.spreadsheet.server.parse.MultiParseResponse;
 import walkingkooka.spreadsheet.server.parse.ParseRequest;
@@ -89,6 +90,10 @@ public final class SpreadsheetServerApiSpreadsheetEngineBiConsumerTest extends S
                         FormatRequest.with(
                                 LocalDate.of(1999, 12, 31),
                                 SpreadsheetFormatPattern.parseDateFormatPattern("yyyy/dd/mm")
+                        ),
+                        FormatRequest.with(
+                                LocalDateTime.of(1999, 12, 31, 12, 58, 59),
+                                SpreadsheetLocaleDefaultDateTimeFormat.INSTANCE
                         )
                 )
         );
@@ -103,7 +108,8 @@ public final class SpreadsheetServerApiSpreadsheetEngineBiConsumerTest extends S
 
         final MultiFormatResponse multiFormatResponse = MultiFormatResponse.with(
                 Lists.of(
-                        SpreadsheetText.with(SpreadsheetText.WITHOUT_COLOR, "1999/31/12")
+                        SpreadsheetText.with(SpreadsheetText.WITHOUT_COLOR, "1999/31/12"),
+                        "31 December 1999, 12:58:59 pm"
                 )
         );
 
@@ -251,7 +257,7 @@ public final class SpreadsheetServerApiSpreadsheetEngineBiConsumerTest extends S
                 .set(SpreadsheetMetadataPropertyName.CREATE_DATE_TIME, now)
                 .set(SpreadsheetMetadataPropertyName.MODIFIED_BY, user)
                 .set(SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME, now)
-                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.forLanguageTag("EN-AU"))
                 .loadFromLocale();
 
         final SpreadsheetMetadataStore metadataStore = SpreadsheetMetadataStores.treeMap();

--- a/src/test/java/walkingkooka/spreadsheet/server/format/MultiFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/format/MultiFormatterTest.java
@@ -94,7 +94,7 @@ public final class MultiFormatterTest extends FormatterTestCase<MultiFormatter>
     }
 
     @Test
-    public void testFormatLocalDateAndLocalTime() {
+    public void testFormatLocalDateAndLocalTimeSpreadsheetDateFormatPattern() {
         this.applyAndCheck(MultiFormatRequest.with(
                 Lists.of(
                         FormatRequest.with(
@@ -111,6 +111,24 @@ public final class MultiFormatterTest extends FormatterTestCase<MultiFormatter>
                         Lists.of(
                                 SpreadsheetText.with(SpreadsheetText.WITHOUT_COLOR, "1999/31/12"),
                                 SpreadsheetText.with(SpreadsheetText.WITHOUT_COLOR, "1999/12/58")
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void testFormatLocalDateAndLocalTimeSpreadsheetLocaleDefaultDateTimeFormat() {
+        this.applyAndCheck(MultiFormatRequest.with(
+                Lists.of(
+                        FormatRequest.with(
+                                LocalDateTime.of(1999, 12, 31, 12, 58, 59),
+                                SpreadsheetLocaleDefaultDateTimeFormat.INSTANCE
+                        )
+                )
+                ),
+                MultiFormatResponse.with(
+                        Lists.of(
+                                "31 December 1999, 12:58:59 pm"
                         )
                 )
         );
@@ -171,6 +189,11 @@ public final class MultiFormatterTest extends FormatterTestCase<MultiFormatter>
                                                 ExpressionNumberKind.DOUBLE
                                         )
                                 ));
+                    }
+
+                    @Override
+                    public Locale locale() {
+                        return Locale.forLanguageTag("EN-AU");
                     }
                 }
         );

--- a/src/test/java/walkingkooka/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormatTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormatTest.java
@@ -18,10 +18,63 @@
 package walkingkooka.spreadsheet.server.format;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.locale.HasLocale;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public final class SpreadsheetLocaleDefaultDateTimeFormatTest extends FormatterTestCase2<SpreadsheetLocaleDefaultDateTimeFormat> {
+
+    @Test
+    public void testFormatNullDateTimeFails() {
+        assertThrows(NullPointerException.class,
+                () -> this.createObject().format(null,
+                        new HasLocale() {
+                            @Override
+                            public Locale locale() {
+                                throw new UnsupportedOperationException();
+                            }
+                        }));
+    }
+
+    @Test
+    public void testFormatNullHasLocaleFails() {
+        assertThrows(NullPointerException.class,
+                () -> this.createObject().format(LocalDateTime.now(),
+                        null));
+    }
+
+    @Test
+    public void testFormatEnAU() {
+        this.formatAndCheck(LocalDateTime.of(1999, 12, 31, 12, 58, 59),
+                Locale.forLanguageTag("EN-AU"),
+                "31 December 1999, 12:58:59 pm");
+    }
+
+    @Test
+    public void testFormatEs() {
+        this.formatAndCheck(LocalDateTime.of(1999, 12, 31, 12, 58, 59),
+                Locale.forLanguageTag("ES"),
+                "31 de diciembre de 1999 12:58:59");
+    }
+
+    private void formatAndCheck(final LocalDateTime dateTime,
+                                final Locale locale,
+                                final String formatted) {
+        assertEquals(formatted,
+                this.createObject().format(dateTime, new HasLocale() {
+                    @Override
+                    public Locale locale() {
+                        return locale;
+                    }
+                }),
+                () -> "format " + dateTime + " with locale " + locale);
+    }
 
     // Json..............................................................................................................
 
@@ -37,7 +90,7 @@ public final class SpreadsheetLocaleDefaultDateTimeFormatTest extends FormatterT
 
     @Test
     public void testToJsonNode() {
-        this.marshallAndCheck(SpreadsheetLocaleDefaultDateTimeFormat.INSTANCE, JsonNode.nullNode());
+        this.marshallAndCheck(SpreadsheetLocaleDefaultDateTimeFormat.INSTANCE, JsonNode.number(1));
     }
 
     @Override


### PR DESCRIPTION
- SpreadsheetLocaleDefaultDateTimeFormat.toJson now 1 was null

- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/126
- SpreadsheetLocaleDefaultDateTimeFormat

- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/125
- Format spreadsheet create-date-time, modified-date-time using users locale and default date-time