### PR TITLE
MultiFormatter force package static inits

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/format/FormatRequest.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/format/FormatRequest.java
@@ -127,4 +127,8 @@ public final class FormatRequest {
                 FormatRequest::marshall,
                 FormatRequest.class);
     }
+
+    // for JsonNodeContext.register to happen
+    static void init() {
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatRequest.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatRequest.java
@@ -83,4 +83,10 @@ public final class MultiFormatRequest {
                 MultiFormatRequest::marshall,
                 MultiFormatRequest.class);
     }
+
+    // for JsonNodeContext.register to happen
+    static void init() {
+        FormatRequest.init();
+        SpreadsheetLocaleDefaultDateTimeFormat.init();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatResponse.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatResponse.java
@@ -83,4 +83,8 @@ public final class MultiFormatResponse {
                 MultiFormatResponse::marshall,
                 MultiFormatResponse.class);
     }
+
+    // for JsonNodeContext.register to happen
+    static void init() {
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/format/MultiFormatter.java
@@ -112,4 +112,9 @@ final class MultiFormatter implements Function<MultiFormatRequest, MultiFormatRe
     public String toString() {
         return this.engineContext.toString();
     }
+
+    static {
+        MultiFormatRequest.init();
+        MultiFormatResponse.init();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormat.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/format/SpreadsheetLocaleDefaultDateTimeFormat.java
@@ -76,4 +76,7 @@ public final class SpreadsheetLocaleDefaultDateTimeFormat {
                 SpreadsheetLocaleDefaultDateTimeFormat::marshall,
                 SpreadsheetLocaleDefaultDateTimeFormat.class);
     }
+
+    static void init() {
+    }
 }


### PR DESCRIPTION
- MultiFormatRequest, FormatRequest, SpreadsheetLocaleDefaultDateTimeFormat, MultiFormatResponse.
- Fixes node unmarshall failures, because types are not registered.