### PR TITLE
server.parse.* force static initializers

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/parse/MultiParseRequest.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/parse/MultiParseRequest.java
@@ -83,4 +83,8 @@ public final class MultiParseRequest {
                 MultiParseRequest::marshall,
                 MultiParseRequest.class);
     }
+
+    static void init() {
+        MultiParser.init();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/server/parse/MultiParseResponse.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/parse/MultiParseResponse.java
@@ -83,4 +83,7 @@ public final class MultiParseResponse {
                 MultiParseResponse::marshall,
                 MultiParseResponse.class);
     }
+
+    static void init() {
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/server/parse/MultiParser.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/parse/MultiParser.java
@@ -136,4 +136,9 @@ final class MultiParser implements Function<MultiParseRequest, MultiParseRespons
     public String toString() {
         return this.engineContext.toString();
     }
+
+    static void init() {
+        MultiParseRequest.init();
+        MultiParseResponse.init();
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/server/parse/ParseRequest.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/parse/ParseRequest.java
@@ -128,4 +128,7 @@ public final class ParseRequest {
                 ParseRequest::marshall,
                 ParseRequest.class);
     }
+
+    static void init() {
+    }
 }


### PR DESCRIPTION
- MultiParseRequest, ParseRequest, MultiParseResponse.
- Fixes node unmarshall failures, because types are not registered.