### PR TITLE
JettyHttpServerSpreadsheetServer default SpreadsheetMetadata EXPRESSI…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetServer.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetServer.java
@@ -175,12 +175,12 @@ public final class JettyHttpServerSpreadsheetServer implements PublicStaticHelpe
                 .set(SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME, now)
                 .set(SpreadsheetMetadataPropertyName.SPREADSHEET_NAME, DEFAULT_NAME)
                 .set(SpreadsheetMetadataPropertyName.LOCALE, localeOrDefault)
-                .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, ExpressionNumberKind.BIG_DECIMAL)
-                .set(SpreadsheetMetadataPropertyName.PRECISION, MathContext.DECIMAL32.getPrecision())
-                .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.HALF_UP)
                 .setDefaults(
                         SpreadsheetMetadata.EMPTY
                                 .set(SpreadsheetMetadataPropertyName.LOCALE, localeOrDefault)
+                                .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, ExpressionNumberKind.DOUBLE)
+                                .set(SpreadsheetMetadataPropertyName.PRECISION, MathContext.DECIMAL32.getPrecision())
+                                .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.HALF_UP)
                                 .loadFromLocale()
                 );
     }


### PR DESCRIPTION
…ON_NUMBER_KIND, PRECISION, ROUNDING_MODE

- set these defaults on the default rather than the user SpreadsheetMetadata.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/148
- JettyHttpServerSpreadsheetServer.prepareInitialMetadata should include a default EXPRESSION_NUMBER_KIND

- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/147
- JettyHttpServerSpreadsheetServer.prepareInitialMetadata should include a default PRECISION

- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/146
- JettyHttpServerSpreadsheetServer.prepareInitialMetadata should include a default ROUNDING_MODE