### PR TITLE
walkingkooka-spreadsheet/issues/1202 SpreadsheetMetadata.decimalNumbe…

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -160,6 +160,11 @@ public class JunitTest {
         return new FakeSpreadsheetEngineContext() {
 
             @Override
+            public ExpressionNumberKind expressionNumberKind() {
+                return EXPRESSION_NUMBER_KIND;
+            }
+
+            @Override
             public SpreadsheetParserToken parseFormula(final String formula) {
                 return Cast.to(SpreadsheetParsers.expression()
                         .orFailIfCursorNotEmpty(ParserReporters.basic())

--- a/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetServerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetServerTest.java
@@ -222,6 +222,31 @@ public final class SpreadsheetServerTest extends SpreadsheetServerTestCase<Sprea
                                 "    \"A1\": {\n" +
                                 "      \"formula\": {\n" +
                                 "        \"text\": \"1+2\",\n" +
+                                "        \"token\": {\n" +
+                                "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                                "          \"value\": {\n" +
+                                "            \"value\": [{\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"1\",\n" +
+                                "                \"text\": \"1\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"+\",\n" +
+                                "                \"text\": \"+\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"2\",\n" +
+                                "                \"text\": \"2\"\n" +
+                                "              }\n" +
+                                "            }],\n" +
+                                "            \"text\": \"1+2\"\n" +
+                                "          }\n" +
+                                "        },\n" +
                                 "        \"expression\": {\n" +
                                 "          \"type\": \"add-expression\",\n" +
                                 "          \"value\": [{\n" +
@@ -275,6 +300,31 @@ public final class SpreadsheetServerTest extends SpreadsheetServerTestCase<Sprea
                                 "    \"A1\": {\n" +
                                 "      \"formula\": {\n" +
                                 "        \"text\": \"1+2\",\n" +
+                                "        \"token\": {\n" +
+                                "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                                "          \"value\": {\n" +
+                                "            \"value\": [{\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"1\",\n" +
+                                "                \"text\": \"1\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"+\",\n" +
+                                "                \"text\": \"+\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"2\",\n" +
+                                "                \"text\": \"2\"\n" +
+                                "              }\n" +
+                                "            }],\n" +
+                                "            \"text\": \"1+2\"\n" +
+                                "          }\n" +
+                                "        },\n" +
                                 "        \"expression\": {\n" +
                                 "          \"type\": \"add-expression\",\n" +
                                 "          \"value\": [{\n" +
@@ -315,6 +365,43 @@ public final class SpreadsheetServerTest extends SpreadsheetServerTestCase<Sprea
                                 "    \"B2\": {\n" +
                                 "      \"formula\": {\n" +
                                 "        \"text\": \"4+A1\",\n" +
+                                "        \"token\": {\n" +
+                                "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                                "          \"value\": {\n" +
+                                "            \"value\": [{\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"4\",\n" +
+                                "                \"text\": \"4\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"+\",\n" +
+                                "                \"text\": \"+\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-cell-reference-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": [{\n" +
+                                "                  \"type\": \"spreadsheet-column-reference-parser-token\",\n" +
+                                "                  \"value\": {\n" +
+                                "                    \"value\": \"A\",\n" +
+                                "                    \"text\": \"A\"\n" +
+                                "                  }\n" +
+                                "                }, {\n" +
+                                "                  \"type\": \"spreadsheet-row-reference-parser-token\",\n" +
+                                "                  \"value\": {\n" +
+                                "                    \"value\": \"1\",\n" +
+                                "                    \"text\": \"1\"\n" +
+                                "                  }\n" +
+                                "                }],\n" +
+                                "                \"text\": \"A1\"\n" +
+                                "              }\n" +
+                                "            }],\n" +
+                                "            \"text\": \"4+A1\"\n" +
+                                "          }\n" +
+                                "        },\n" +
                                 "        \"expression\": {\n" +
                                 "          \"type\": \"add-expression\",\n" +
                                 "          \"value\": [{\n" +
@@ -370,6 +457,31 @@ public final class SpreadsheetServerTest extends SpreadsheetServerTestCase<Sprea
                                 "    \"A1\": {\n" +
                                 "      \"formula\": {\n" +
                                 "        \"text\": \"1+2\",\n" +
+                                "        \"token\": {\n" +
+                                "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                                "          \"value\": {\n" +
+                                "            \"value\": [{\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"1\",\n" +
+                                "                \"text\": \"1\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"+\",\n" +
+                                "                \"text\": \"+\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"2\",\n" +
+                                "                \"text\": \"2\"\n" +
+                                "              }\n" +
+                                "            }],\n" +
+                                "            \"text\": \"1+2\"\n" +
+                                "          }\n" +
+                                "        },\n" +
                                 "        \"expression\": {\n" +
                                 "          \"type\": \"add-expression\",\n" +
                                 "          \"value\": [{\n" +
@@ -419,6 +531,31 @@ public final class SpreadsheetServerTest extends SpreadsheetServerTestCase<Sprea
                                 "    \"A1\": {\n" +
                                 "      \"formula\": {\n" +
                                 "        \"text\": \"3+4\",\n" +
+                                "        \"token\": {\n" +
+                                "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                                "          \"value\": {\n" +
+                                "            \"value\": [{\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"3\",\n" +
+                                "                \"text\": \"3\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"+\",\n" +
+                                "                \"text\": \"+\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"4\",\n" +
+                                "                \"text\": \"4\"\n" +
+                                "              }\n" +
+                                "            }],\n" +
+                                "            \"text\": \"3+4\"\n" +
+                                "          }\n" +
+                                "        },\n" +
                                 "        \"expression\": {\n" +
                                 "          \"type\": \"add-expression\",\n" +
                                 "          \"value\": [{\n" +
@@ -460,6 +597,43 @@ public final class SpreadsheetServerTest extends SpreadsheetServerTestCase<Sprea
                                 "    \"B2\": {\n" +
                                 "      \"formula\": {\n" +
                                 "        \"text\": \"4+A1\",\n" +
+                                "        \"token\": {\n" +
+                                "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                                "          \"value\": {\n" +
+                                "            \"value\": [{\n" +
+                                "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"4\",\n" +
+                                "                \"text\": \"4\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": \"+\",\n" +
+                                "                \"text\": \"+\"\n" +
+                                "              }\n" +
+                                "            }, {\n" +
+                                "              \"type\": \"spreadsheet-cell-reference-parser-token\",\n" +
+                                "              \"value\": {\n" +
+                                "                \"value\": [{\n" +
+                                "                  \"type\": \"spreadsheet-column-reference-parser-token\",\n" +
+                                "                  \"value\": {\n" +
+                                "                    \"value\": \"A\",\n" +
+                                "                    \"text\": \"A\"\n" +
+                                "                  }\n" +
+                                "                }, {\n" +
+                                "                  \"type\": \"spreadsheet-row-reference-parser-token\",\n" +
+                                "                  \"value\": {\n" +
+                                "                    \"value\": \"1\",\n" +
+                                "                    \"text\": \"1\"\n" +
+                                "                  }\n" +
+                                "                }],\n" +
+                                "                \"text\": \"A1\"\n" +
+                                "              }\n" +
+                                "            }],\n" +
+                                "            \"text\": \"4+A1\"\n" +
+                                "          }\n" +
+                                "        },\n" +
                                 "        \"expression\": {\n" +
                                 "          \"type\": \"add-expression\",\n" +
                                 "          \"value\": [{\n" +
@@ -565,6 +739,7 @@ public final class SpreadsheetServerTest extends SpreadsheetServerTestCase<Sprea
                 .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E")
                 .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, EXPRESSION_NUMBER_KIND)
                 .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                .loadFromLocale()
                 .set(SpreadsheetMetadataPropertyName.PRECISION, 10)
                 .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.HALF_UP)
                 .set(SpreadsheetMetadataPropertyName.STYLE, SpreadsheetMetadata.NON_LOCALE_DEFAULTS.getOrFail(SpreadsheetMetadataPropertyName.STYLE))

--- a/src/test/java/walkingkooka/spreadsheet/server/context/MemorySpreadsheetContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/context/MemorySpreadsheetContextTest.java
@@ -210,6 +210,31 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                         "    \"B2\": {\n" +
                         "      \"formula\": {\n" +
                         "        \"text\": \"1+2\",\n" +
+                        "        \"token\": {\n" +
+                        "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                        "          \"value\": {\n" +
+                        "            \"value\": [{\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"1\",\n" +
+                        "                \"text\": \"1\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"+\",\n" +
+                        "                \"text\": \"+\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"2\",\n" +
+                        "                \"text\": \"2\"\n" +
+                        "              }\n" +
+                        "            }],\n" +
+                        "            \"text\": \"1+2\"\n" +
+                        "          }\n" +
+                        "        },\n" +
                         "        \"expression\": {\n" +
                         "          \"type\": \"add-expression\",\n" +
                         "          \"value\": [{\n" +
@@ -240,6 +265,31 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                         "    \"B2\": {\n" +
                         "      \"formula\": {\n" +
                         "        \"text\": \"1+2\",\n" +
+                        "        \"token\": {\n" +
+                        "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                        "          \"value\": {\n" +
+                        "            \"value\": [{\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"1\",\n" +
+                        "                \"text\": \"1\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"+\",\n" +
+                        "                \"text\": \"+\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"2\",\n" +
+                        "                \"text\": \"2\"\n" +
+                        "              }\n" +
+                        "            }],\n" +
+                        "            \"text\": \"1+2\"\n" +
+                        "          }\n" +
+                        "        },\n" +
                         "        \"expression\": {\n" +
                         "          \"type\": \"add-expression\",\n" +
                         "          \"value\": [{\n" +
@@ -278,6 +328,31 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                         "    \"B2\": {\n" +
                         "      \"formula\": {\n" +
                         "        \"text\": \"1+2\",\n" +
+                        "        \"token\": {\n" +
+                        "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                        "          \"value\": {\n" +
+                        "            \"value\": [{\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"1\",\n" +
+                        "                \"text\": \"1\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"+\",\n" +
+                        "                \"text\": \"+\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"2\",\n" +
+                        "                \"text\": \"2\"\n" +
+                        "              }\n" +
+                        "            }],\n" +
+                        "            \"text\": \"1+2\"\n" +
+                        "          }\n" +
+                        "        },\n" +
                         "        \"expression\": {\n" +
                         "          \"type\": \"add-expression\",\n" +
                         "          \"value\": [{\n" +
@@ -316,6 +391,31 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                         "    \"B2\": {\n" +
                         "      \"formula\": {\n" +
                         "        \"text\": \"1+2\",\n" +
+                        "        \"token\": {\n" +
+                        "          \"type\": \"spreadsheet-addition-parser-token\",\n" +
+                        "          \"value\": {\n" +
+                        "            \"value\": [{\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"1\",\n" +
+                        "                \"text\": \"1\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-plus-symbol-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"+\",\n" +
+                        "                \"text\": \"+\"\n" +
+                        "              }\n" +
+                        "            }, {\n" +
+                        "              \"type\": \"spreadsheet-expression-number-parser-token\",\n" +
+                        "              \"value\": {\n" +
+                        "                \"value\": \"2\",\n" +
+                        "                \"text\": \"2\"\n" +
+                        "              }\n" +
+                        "            }],\n" +
+                        "            \"text\": \"1+2\"\n" +
+                        "          }\n" +
+                        "        },\n" +
                         "        \"expression\": {\n" +
                         "          \"type\": \"add-expression\",\n" +
                         "          \"value\": [{\n" +
@@ -645,9 +745,11 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                     .set(SpreadsheetMetadataPropertyName.MODIFIED_BY, creator)
                     .set(SpreadsheetMetadataPropertyName.MODIFIED_DATE_TIME, now)
                     .set(SpreadsheetMetadataPropertyName.DATETIME_OFFSET, Converters.JAVA_EPOCH_OFFSET)
+                    .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
+                    .loadFromLocale()
+                    .set(SpreadsheetMetadataPropertyName.CURRENCY_SYMBOL, "C")
                     .set(SpreadsheetMetadataPropertyName.EXPONENT_SYMBOL, "E")
                     .set(SpreadsheetMetadataPropertyName.EXPRESSION_NUMBER_KIND, EXPRESSION_NUMBER_KIND)
-                    .set(SpreadsheetMetadataPropertyName.LOCALE, Locale.ENGLISH)
                     .set(SpreadsheetMetadataPropertyName.PRECISION, 10)
                     .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.HALF_UP)
                     .set(SpreadsheetMetadataPropertyName.STYLE, SpreadsheetMetadata.NON_LOCALE_DEFAULTS.getOrFail(SpreadsheetMetadataPropertyName.STYLE))

--- a/src/test/java/walkingkooka/spreadsheet/server/sample/Sample.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/sample/Sample.java
@@ -157,6 +157,11 @@ public final class Sample {
         return new FakeSpreadsheetEngineContext() {
 
             @Override
+            public ExpressionNumberKind expressionNumberKind() {
+                return EXPRESSION_NUMBER_KIND;
+            }
+
+            @Override
             public SpreadsheetParserToken parseFormula(final String formula) {
                 return Cast.to(SpreadsheetParsers.expression()
                         .orFailIfCursorNotEmpty(ParserReporters.basic())


### PR DESCRIPTION
…rContext no longer Locale defaults + 2

- https://github.com/mP1/walkingkooka-spreadsheet/pull/1202
- SpreadsheetMetadata.decimalNumberContext no longer Locale defaults
- had to init some SpreadsheetMetadata.loadLocaleDefaults()

- https://github.com/mP1/walkingkooka-spreadsheet/pull/1199
- SpreadsheetParserTokenToExpressionSpreadsheetParserTokenVisitor.accept(ExpressionNumberKind) replaces ExpressionNumberContext

- https://github.com/mP1/walkingkooka-spreadsheet/pull/1189
- SpreadsheetFormula.token
- required updates to several expected JSON response bodies