### PR TITLE
JettyHttpServerSpreadsheetServer default TWO_DIGIT_YEAR

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetServer.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetServer.java
@@ -185,6 +185,7 @@ public final class JettyHttpServerSpreadsheetServer implements PublicStaticHelpe
                                 .set(SpreadsheetMetadataPropertyName.PRECISION, MathContext.DECIMAL32.getPrecision())
                                 .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.HALF_UP)
                                 .set(SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN, SpreadsheetPattern.parseTextFormatPattern("@"))
+                                .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 20)
                 );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-react/issues/590
- settings: two-digit-year missing default button