### PR TITLE
JettyHttpServerSpreadsheetServer default WIDTH

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetServer.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetServer.java
@@ -186,6 +186,7 @@ public final class JettyHttpServerSpreadsheetServer implements PublicStaticHelpe
                                 .set(SpreadsheetMetadataPropertyName.ROUNDING_MODE, RoundingMode.HALF_UP)
                                 .set(SpreadsheetMetadataPropertyName.TEXT_FORMAT_PATTERN, SpreadsheetPattern.parseTextFormatPattern("@"))
                                 .set(SpreadsheetMetadataPropertyName.TWO_DIGIT_YEAR, 20)
+                                .set(SpreadsheetMetadataPropertyName.WIDTH, 1)
                 );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/178
- JettyHttpServerSpreadsheetServer default SpreadsheetMetadata missing width property