### PR TITLE
JettyHttpServerSpreadsheetHttpServer load cell formula metadata aware

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetHttpServer.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/JettyHttpServerSpreadsheetHttpServer.java
@@ -226,7 +226,7 @@ public final class JettyHttpServerSpreadsheetHttpServer implements PublicStaticH
         return (id) -> {
             SpreadsheetStoreRepository repository = idToRepository.get(id);
             if (null == repository) {
-                repository = repositoryFactory.get();
+                repository = SpreadsheetStoreRepositories.spreadsheetMetadataAwareSpreadsheetCellStore(id, repositoryFactory.get());
                 idToRepository.put(id, repository); // TODO add locks etc.
             }
             return repository;


### PR DESCRIPTION
- Reimplements recent change that broke this feature.
- Some react web app cypress it test remain broken.