### PR TITLE
SpreadsheetEngineHateosHandlerSpreadsheetDeltaLoadCell home viewport …

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/engine/http/SpreadsheetEngineHateosHandlerSpreadsheetDeltaLoadCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/engine/http/SpreadsheetEngineHateosHandlerSpreadsheetDeltaLoadCell.java
@@ -93,7 +93,8 @@ final class SpreadsheetEngineHateosHandlerSpreadsheetDeltaLoadCell extends Sprea
         );
 
         final SpreadsheetViewportWindows window = this.engine.window(
-                viewport.rectangle(),
+                navigatedViewport.orElse(viewport)
+                        .rectangle(),
                 true, // includeFrozenColumnsRows,
                 SpreadsheetEngine.NO_SELECTION, // no selection
                 context


### PR DESCRIPTION
…navigation movement window FIX

- previously window computation was using original not navigation updated window.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/695
- load cells with pixel navigation returning incorrect window.