### PR TITLE
SpreadsheetContextMetadataPatchFunction SpreadsheetEngine.saveMetadata

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/context/SpreadsheetContextMetadataPatchFunction.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/context/SpreadsheetContextMetadataPatchFunction.java
@@ -19,7 +19,6 @@ package walkingkooka.spreadsheet.server.context;
 
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.spreadsheet.meta.SpreadsheetMetadata;
-import walkingkooka.spreadsheet.meta.store.SpreadsheetMetadataStore;
 import walkingkooka.store.MissingStoreException;
 import walkingkooka.tree.json.JsonNode;
 
@@ -51,15 +50,16 @@ final class SpreadsheetContextMetadataPatchFunction implements UnaryOperator<Jso
         final SpreadsheetId id = this.id;
 
         try {
-            final SpreadsheetMetadataStore store = this.context.storeRepository(id)
-                    .metadatas();
-
-            final SpreadsheetMetadata loadAndPatched = store.loadOrFail(id);
-            final SpreadsheetMetadata saved = store.save(loadAndPatched
-                    .patch(
+            final SpreadsheetContext context = this.context;
+            final SpreadsheetMetadata loadAndPatched = context.storeRepository(id)
+                    .metadatas()
+                    .loadOrFail(id);
+            final SpreadsheetMetadata saved = context.saveMetadata(
+                    loadAndPatched
+                            .patch(
                             json,
                             loadAndPatched.jsonNodeUnmarshallContext()
-                    )
+                            )
             );
             return saved.jsonNodeMarshallContext()
                     .marshall(saved);

--- a/src/test/java/walkingkooka/spreadsheet/server/context/SpreadsheetContextMetadataPatchFunctionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/context/SpreadsheetContextMetadataPatchFunctionTest.java
@@ -117,6 +117,12 @@ public final class SpreadsheetContextMetadataPatchFunctionTest implements Functi
         );
 
         final SpreadsheetContext context = new FakeSpreadsheetContext() {
+
+            @Override
+            public SpreadsheetMetadata saveMetadata(final SpreadsheetMetadata metadata) {
+                return metadata;
+            }
+
             @Override
             public SpreadsheetStoreRepository storeRepository(final SpreadsheetId id) {
                 checkEquals(ID, id, "id");


### PR DESCRIPTION
- Previously saved to the metadata store, never checking if the a selection label was valid.