### PR TITLE
PluginFileDownloadHttpHandler response X-Content-Type-Name JarEntryIn…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/plugin/PluginFileDownloadHttpHandler.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/plugin/PluginFileDownloadHttpHandler.java
@@ -28,6 +28,7 @@ import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.json.JsonHttpHandlers;
 import walkingkooka.net.http.server.HttpHandler;
 import walkingkooka.net.http.server.HttpRequest;
 import walkingkooka.net.http.server.HttpResponse;
@@ -126,6 +127,9 @@ final class PluginFileDownloadHttpHandler implements HttpHandler {
                                     ContentDispositionType.ATTACHMENT.setFilename(
                                             ContentDispositionFileName.notEncoded(pluginFilename)
                                     )
+                            ).addHeader(
+                                    JsonHttpHandlers.X_CONTENT_TYPE_NAME,
+                                    JarEntryInfoName.class.getSimpleName()
                             ).setBody(archive)
                             .setContentLength();
                 }

--- a/src/main/java/walkingkooka/spreadsheet/server/plugin/PluginFileDownloadHttpHandlerFileExtractor.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/plugin/PluginFileDownloadHttpHandlerFileExtractor.java
@@ -25,6 +25,7 @@ import walkingkooka.net.header.ContentDispositionType;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.HttpEntity;
+import walkingkooka.net.http.json.JsonHttpHandlers;
 
 import java.io.IOException;
 import java.util.function.BiFunction;
@@ -70,6 +71,9 @@ class PluginFileDownloadHttpHandlerFileExtractor extends PluginFileDownloadHttpH
                                         ContentDispositionType.ATTACHMENT.setFilename(
                                                 ContentDispositionFileName.notEncoded(filename)
                                         )
+                                ).addHeader(
+                                        JsonHttpHandlers.X_CONTENT_TYPE_NAME,
+                                        JarEntryInfoName.class.getSimpleName()
                                 ).setBody(content)
                                 .setContentLength();
                     }

--- a/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetHttpServerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetHttpServerTest.java
@@ -53,6 +53,7 @@ import walkingkooka.net.http.HttpProtocolVersion;
 import walkingkooka.net.http.HttpStatus;
 import walkingkooka.net.http.HttpStatusCode;
 import walkingkooka.net.http.HttpTransport;
+import walkingkooka.net.http.json.JsonHttpHandlers;
 import walkingkooka.net.http.server.HttpHandler;
 import walkingkooka.net.http.server.HttpRequest;
 import walkingkooka.net.http.server.HttpRequestParameterName;
@@ -112,6 +113,7 @@ import walkingkooka.spreadsheet.server.formatter.SpreadsheetFormatterSelectorEdi
 import walkingkooka.spreadsheet.server.formatter.SpreadsheetFormatterSelectorMenuList;
 import walkingkooka.spreadsheet.server.parser.SpreadsheetParserSelectorEdit;
 import walkingkooka.spreadsheet.server.plugin.JarEntryInfoList;
+import walkingkooka.spreadsheet.server.plugin.JarEntryInfoName;
 import walkingkooka.spreadsheet.store.SpreadsheetCellRangeStores;
 import walkingkooka.spreadsheet.store.SpreadsheetCellStores;
 import walkingkooka.spreadsheet.store.SpreadsheetColumnStores;
@@ -900,6 +902,9 @@ public final class SpreadsheetHttpServerTest extends SpreadsheetHttpServerTestCa
                                         ContentDispositionType.ATTACHMENT.setFilename(
                                                 ContentDispositionFileName.notEncoded("TestPlugin111-download.jar")
                                         )
+                                ).addHeader(
+                                        JsonHttpHandlers.X_CONTENT_TYPE_NAME,
+                                        JarEntryInfoName.class.getSimpleName()
                                 ).setBody(
                                         plugin.archive()
                                 ).setContentLength()
@@ -948,6 +953,9 @@ public final class SpreadsheetHttpServerTest extends SpreadsheetHttpServerTestCa
                                         ContentDispositionType.ATTACHMENT.setFilename(
                                                 ContentDispositionFileName.notEncoded("TestPlugin111-download.jar")
                                         )
+                                ).addHeader(
+                                        JsonHttpHandlers.X_CONTENT_TYPE_NAME,
+                                        JarEntryInfoName.class.getSimpleName()
                                 ).setBody(
                                         plugin.archive()
                                 ).setContentLength()
@@ -1117,6 +1125,9 @@ public final class SpreadsheetHttpServerTest extends SpreadsheetHttpServerTestCa
                                         ContentDispositionType.ATTACHMENT.setFilename(
                                                 ContentDispositionFileName.notEncoded("/example/Example.java")
                                         )
+                                ).addHeader(
+                                        JsonHttpHandlers.X_CONTENT_TYPE_NAME,
+                                        JarEntryInfoName.class.getSimpleName()
                                 ).setBodyText(fileContent)
                                 .setContentLength()
                 )

--- a/src/test/java/walkingkooka/spreadsheet/server/plugin/PluginFileDownloadHttpHandlerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/plugin/PluginFileDownloadHttpHandlerTest.java
@@ -32,6 +32,7 @@ import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpProtocolVersion;
 import walkingkooka.net.http.HttpStatusCode;
 import walkingkooka.net.http.HttpTransport;
+import walkingkooka.net.http.json.JsonHttpHandlers;
 import walkingkooka.net.http.server.HttpHandlerTesting;
 import walkingkooka.net.http.server.HttpRequests;
 import walkingkooka.net.http.server.HttpResponse;
@@ -96,6 +97,9 @@ public final class PluginFileDownloadHttpHandlerTest implements HttpHandlerTesti
                     ContentDispositionType.ATTACHMENT.setFilename(
                             ContentDispositionFileName.notEncoded("/dir111/sub111/Example111.java")
                     )
+            ).addHeader(
+                    JsonHttpHandlers.X_CONTENT_TYPE_NAME,
+                    JarEntryInfoName.class.getSimpleName()
             ).setBodyText(CONTENT)
             .setContentLength();
 
@@ -107,6 +111,9 @@ public final class PluginFileDownloadHttpHandlerTest implements HttpHandlerTesti
                     ContentDispositionType.ATTACHMENT.setFilename(
                             ContentDispositionFileName.notEncoded("TestPlugin123.jar")
                     )
+            ).addHeader(
+                    JsonHttpHandlers.X_CONTENT_TYPE_NAME,
+                    JarEntryInfoName.class.getSimpleName()
             ).setBody(JAR_FILE)
             .setContentLength();
 


### PR DESCRIPTION
…foName

- Previously was missing making it difficult for PluginFetcher to identify and dispatch download responses.