### PR TITLE
SpreadsheetDeltaHateosResourceHandlerClearColumns empty resource FIX

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearColumns.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearColumns.java
@@ -86,7 +86,7 @@ final class SpreadsheetDeltaHateosResourceHandlerClearColumns extends Spreadshee
                                                   final Optional<SpreadsheetDelta> resource,
                                                   final Map<HttpRequestAttribute<?>, Object> parameters,
                                                   final SpreadsheetEngineHateosResourceHandlerContext context) {
-        HateosResourceHandler.checkResourceNotEmpty(resource);
+        HateosResourceHandler.checkResourceEmpty(resource);
         HateosResourceHandler.checkParameters(parameters);
         HateosResourceHandler.checkContext(context);
 

--- a/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetHttpServerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetHttpServerTest.java
@@ -6129,7 +6129,7 @@ public final class SpreadsheetHttpServerTest extends SpreadsheetHttpServerTestCa
         server.handleAndCheck(HttpMethod.POST,
             "/api/spreadsheet/1/column/B/clear",
             NO_HEADERS_TRANSACTION_ID,
-            toJson(SpreadsheetDelta.EMPTY),
+            "",
             this.response(
                 HttpStatusCode.OK.status(),
                 "{\n" +
@@ -6242,7 +6242,7 @@ public final class SpreadsheetHttpServerTest extends SpreadsheetHttpServerTestCa
         server.handleAndCheck(HttpMethod.POST,
             "/api/spreadsheet/1/column/A:C/clear",
             NO_HEADERS_TRANSACTION_ID,
-            toJson(SpreadsheetDelta.EMPTY),
+            "",
             this.response(
                 HttpStatusCode.OK.status(),
                 "{\n" +

--- a/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearColumnsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearColumnsTest.java
@@ -42,7 +42,7 @@ import java.util.OptionalInt;
 public final class SpreadsheetDeltaHateosResourceHandlerClearColumnsTest extends SpreadsheetDeltaHateosResourceHandlerTestCase2<SpreadsheetDeltaHateosResourceHandlerClearColumns,
     SpreadsheetColumnReference> {
 
-    private final static Optional<SpreadsheetDelta> RESOURCE = Optional.of(SpreadsheetDelta.EMPTY);
+    private final static Optional<SpreadsheetDelta> RESOURCE = Optional.empty();
 
     @Test
     public void testClearColumn() {

--- a/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHttpMappingsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHttpMappingsTest.java
@@ -632,10 +632,7 @@ public final class SpreadsheetDeltaHttpMappingsTest implements ClassTesting2<Spr
         this.routeColumnAndCheck(
             HttpMethod.POST,
             "/column/A/clear",
-            JsonNodeMarshallContexts.basic()
-                .marshall(
-                    SpreadsheetDelta.EMPTY
-                ).toString(),
+            "",
             HttpStatusCode.OK
         );
     }
@@ -645,10 +642,7 @@ public final class SpreadsheetDeltaHttpMappingsTest implements ClassTesting2<Spr
         this.routeColumnAndCheck(
             HttpMethod.POST,
             "/column/A:B/clear",
-            JsonNodeMarshallContexts.basic()
-                .marshall(
-                    SpreadsheetDelta.EMPTY
-                ).toString(),
+            "",
             HttpStatusCode.OK
         );
     }


### PR DESCRIPTION
- Previously requests were being sent an empty SpreadsheetDelta which was ignored anyway.
- The guard now validates that the post body is empty