### PR TITLE
SpreadsheetDeltaHateosResourceHandlerClearRows require empty resource…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearRows.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearRows.java
@@ -87,7 +87,7 @@ final class SpreadsheetDeltaHateosResourceHandlerClearRows extends SpreadsheetDe
                                                   final Map<HttpRequestAttribute<?>, Object> parameters,
                                                   final SpreadsheetEngineHateosResourceHandlerContext context) {
         Objects.requireNonNull(rows, "rows");
-        HateosResourceHandler.checkResourceNotEmpty(resource);
+        HateosResourceHandler.checkResourceEmpty(resource);
         HateosResourceHandler.checkParameters(parameters);
         HateosResourceHandler.checkContext(context);
 

--- a/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetHttpServerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/SpreadsheetHttpServerTest.java
@@ -8356,7 +8356,7 @@ public final class SpreadsheetHttpServerTest extends SpreadsheetHttpServerTestCa
         server.handleAndCheck(HttpMethod.POST,
             "/api/spreadsheet/1/row/2/clear",
             NO_HEADERS_TRANSACTION_ID,
-            toJson(SpreadsheetDelta.EMPTY),
+            "",
             this.response(
                 HttpStatusCode.OK.status(),
                 "{\n" +
@@ -8469,7 +8469,7 @@ public final class SpreadsheetHttpServerTest extends SpreadsheetHttpServerTestCa
         server.handleAndCheck(HttpMethod.POST,
             "/api/spreadsheet/1/row/1:3/clear",
             NO_HEADERS_TRANSACTION_ID,
-            toJson(SpreadsheetDelta.EMPTY),
+            "",
             this.response(
                 HttpStatusCode.OK.status(),
                 "{\n" +

--- a/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearRowsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerClearRowsTest.java
@@ -43,7 +43,7 @@ import java.util.OptionalInt;
 public final class SpreadsheetDeltaHateosResourceHandlerClearRowsTest extends SpreadsheetDeltaHateosResourceHandlerTestCase2<SpreadsheetDeltaHateosResourceHandlerClearRows,
     SpreadsheetRowReference> {
 
-    private final static Optional<SpreadsheetDelta> RESOURCE = Optional.of(SpreadsheetDelta.EMPTY);
+    private final static Optional<SpreadsheetDelta> RESOURCE = Optional.empty();
 
     @Test
     public void testHandleOneClearRow() {

--- a/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHttpMappingsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHttpMappingsTest.java
@@ -811,10 +811,7 @@ public final class SpreadsheetDeltaHttpMappingsTest implements ClassTesting2<Spr
         this.routeRowAndCheck(
             HttpMethod.POST,
             "/row/1/clear",
-            JsonNodeMarshallContexts.basic()
-                .marshall(
-                    SpreadsheetDelta.EMPTY
-                ).toString(),
+            "",
             HttpStatusCode.OK
         );
     }
@@ -824,10 +821,7 @@ public final class SpreadsheetDeltaHttpMappingsTest implements ClassTesting2<Spr
         this.routeRowAndCheck(
             HttpMethod.POST,
             "/row/1:2/clear",
-            JsonNodeMarshallContexts.basic()
-                .marshall(
-                    SpreadsheetDelta.EMPTY
-                ).toString(),
+            "",
             HttpStatusCode.OK
         );
     }


### PR DESCRIPTION
… FIX

- Previously a non empty resource was required and ignored completely.