### PR TITLE
SpreadsheetFormatterSelectorMenuList null element check

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/server/formatter/SpreadsheetFormatterSelectorMenuList.java
+++ b/src/main/java/walkingkooka/spreadsheet/server/formatter/SpreadsheetFormatterSelectorMenuList.java
@@ -41,9 +41,20 @@ public final class SpreadsheetFormatterSelectorMenuList extends AbstractList<Spr
 
         return menus instanceof SpreadsheetFormatterSelectorMenuList ?
             (SpreadsheetFormatterSelectorMenuList) menus :
-            new SpreadsheetFormatterSelectorMenuList(
-                Lists.immutable(menus)
+            withCopy(menus);
+    }
+
+    private static SpreadsheetFormatterSelectorMenuList withCopy(final List<SpreadsheetFormatterSelectorMenu> menus) {
+        Objects.requireNonNull(menus, "menus");
+
+        final List<SpreadsheetFormatterSelectorMenu> copy = Lists.array();
+        for (final SpreadsheetFormatterSelectorMenu menu : menus) {
+            copy.add(
+                Objects.requireNonNull(menu, "includes null menu")
             );
+        }
+
+        return new SpreadsheetFormatterSelectorMenuList(copy);
     }
 
     private SpreadsheetFormatterSelectorMenuList(final List<SpreadsheetFormatterSelectorMenu> menus) {

--- a/src/test/java/walkingkooka/spreadsheet/server/formatter/SpreadsheetFormatterSelectorMenuListTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/formatter/SpreadsheetFormatterSelectorMenuListTest.java
@@ -28,6 +28,8 @@ import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -51,6 +53,19 @@ public class SpreadsheetFormatterSelectorMenuListTest implements ListTesting2<Sp
         assertThrows(
             NullPointerException.class,
             () -> SpreadsheetFormatterSelectorMenuList.with(null)
+        );
+    }
+
+    @Test
+    public void testWithIncludesNullFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> SpreadsheetFormatterSelectorMenuList.with(
+                Arrays.asList(
+                    MENU1,
+                    null
+                )
+            )
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-spreadsheet-server/issues/1446
- SpreadsheetFormatterSelectorMenuList.setElements should null check