### PR TITLE
POM: maven-central-snapshots FIX

### DIFF
--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,3 +1,20 @@
+<!--
+  ~ Copyright 2019 Miroslav Pokorny (github.com/mP1)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
 <settings>
     <profiles>
         <profile>
@@ -31,8 +48,8 @@
                     </snapshots>
                 </repository>
                 <repository>
-                    <id>google-sonatype-snapshots</id>
-                    <url>https://oss.sonatype.org/content/repositories/google-snapshots/</url>
+                    <id>maven.repository.snapshots</id>
+                    <url>https://central.sonatype.org/repository/maven-snapshots/</url>
                     <releases>
                         <enabled>true</enabled>
                         <updatePolicy>never</updatePolicy>


### PR DESCRIPTION
- Previous commit failed to replace all google-snapshot entries