### PR TITLE
https://github.com/mP1/walkingkooka-storage/pull/138 Revert "Storage:…

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerTestCase2.java
+++ b/src/test/java/walkingkooka/spreadsheet/server/delta/SpreadsheetDeltaHateosResourceHandlerTestCase2.java
@@ -89,6 +89,7 @@ import walkingkooka.spreadsheet.value.SpreadsheetCell;
 import walkingkooka.spreadsheet.viewport.SpreadsheetViewportWindows;
 import walkingkooka.storage.Storage;
 import walkingkooka.storage.Storages;
+import walkingkooka.storage.expression.function.StorageExpressionEvaluationContext;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.tree.expression.Expression;
 import walkingkooka.tree.expression.ExpressionNumberKind;
@@ -393,7 +394,7 @@ public abstract class SpreadsheetDeltaHateosResourceHandlerTestCase2<H extends S
             private final SpreadsheetRowStore rowStore = SpreadsheetRowStores.treeMap();
 
             @Override
-            public Storage storage() {
+            public Storage<StorageExpressionEvaluationContext> storage() {
                 return Storages.fake();
             }
         };


### PR DESCRIPTION
… StorageContext type-parameter removed"

- https://github.com/mP1/walkingkooka-storage/pull/138
- Revert "Storage: StorageContext type-parameter removed"

This reverts (previous) commit 296446ad924f76eb2efc4d5794c21d126e7db696.